### PR TITLE
Replace tiny.one to tinyurl.com

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,12 +5,12 @@ The AltStore Repo For [SpotC](https://github.com/SpotCompiled).
 
 ### Option One:<br/>
 You can add my repo to AltStore *Beta* or SideStore for automatic updates and conviniance, by following the steps below:<br/>
-[Click this link](https://tinyurl.com/SpotC-Import) on your device with SideStore/AltStore and it will open SideStore/AltStore with it prompting you to add the source.
+[Click this link](https://tinyurl.com/SpotCRepo-Import) on your device with SideStore/AltStore and it will open SideStore/AltStore with it prompting you to add the source.
 
 ### Option Two:<br/>
 You can add my repo to AltStore *Beta* or SideStore for automatic updates and conviniance, by following the steps below:<br/>
 1. Tap "Sources" in the top-right corner of the Browse tab.<br/>
-2. Tap the ”+” button and add my source by entering its URL "https://tiny.one/SpotC"
+2. Tap the ”+” button and add my source by entering its URL "https://tinyurl.com/SpotC"
 3. Now any "SpotC" Apps will show up in AltStore/SideStore under the "Browse" tab where you can install and update my apps easily from within AltStore/SideStore.<br/>
 ***
 <sup>We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with any other company, agency or government agency. All product and company names are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</sup>

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ You can add my repo to AltStore *Beta* or SideStore for automatic updates and co
 ### Option Two:<br/>
 You can add my repo to AltStore *Beta* or SideStore for automatic updates and conviniance, by following the steps below:<br/>
 1. Tap "Sources" in the top-right corner of the Browse tab.<br/>
-2. Tap the ”+” button and add my source by entering its URL "https://tinyurl.com/SpotC"
+2. Tap the ”+” button and add my source by entering its URL "https://tinyurl.com/SpotCRepo"
 3. Now any "SpotC" Apps will show up in AltStore/SideStore under the "Browse" tab where you can install and update my apps easily from within AltStore/SideStore.<br/>
 ***
 <sup>We are not affiliated, associated, authorized, endorsed by, or in any way officially connected with any other company, agency or government agency. All product and company names are trademarks™ or registered® trademarks of their respective holders. Use of them does not imply any affiliation with or endorsement by them.</sup>


### PR DESCRIPTION
Changed tiny.one to tinyurl.com because tiny.one has expired.